### PR TITLE
Update to use digikey v4 api

### DIFF
--- a/inventree_part_import/suppliers/supplier_digikey.py
+++ b/inventree_part_import/suppliers/supplier_digikey.py
@@ -1,7 +1,9 @@
 import logging, os
 
 import digikey
-from digikey.v3.productinformation import KeywordSearchRequest, KeywordSearchResponse
+from digikey import DigikeyApi
+from digikey.v4.productinformation import KeywordRequest, KeywordResponse, Product
+from digikey.v4.productinformation.api import ProductSearchApi
 from platformdirs import user_cache_path
 
 from .. import __package__ as parent_package
@@ -13,13 +15,10 @@ DIGIKEY_CACHE = user_cache_path(parent_package, ensure_exists=True) / "digikey"
 DIGIKEY_CACHE.mkdir(parents=True, exist_ok=True)
 
 class DigiKey(Supplier):
+    
     SUPPORT_LEVEL = SupplierSupportLevel.OFFICIAL_API
 
     def setup(self, client_id, client_secret, currency, language, location):
-        os.environ["DIGIKEY_CLIENT_ID"] = client_id
-        os.environ["DIGIKEY_CLIENT_SECRET"] = client_secret
-        os.environ["DIGIKEY_CLIENT_SANDBOX"] = "False"
-        os.environ["DIGIKEY_STORAGE_PATH"] = str(DIGIKEY_CACHE)
 
         if not get_country(location):
             return self.load_error(f"invalid country code '{location}'")
@@ -31,44 +30,51 @@ class DigiKey(Supplier):
         self.language = language
         self.location = location
 
-        logging.getLogger("digikey.v3.api").setLevel(logging.CRITICAL)
-
+        logging.getLogger("digikey.v4.api").setLevel(logging.CRITICAL)
+        self.client = DigikeyApi(
+            client_id=client_id,
+            client_secret=client_secret,
+            storage_path=str(DIGIKEY_CACHE),
+        )        
+        
         return True
 
     def search(self, search_term):
         for retry in retry_timeouts():
             with retry:
-                digikey_part = digikey.product_details(
-                    search_term,
-                    x_digikey_locale_currency=self.currency,
-                    x_digikey_locale_site=self.location,
-                    x_digikey_locale_language=self.language,
-                )
-        if digikey_part and search_term == digikey_part.digi_key_part_number:
-            return [self.get_api_part(digikey_part)], 1
+                try:
+                    digikey_part = self.client.product_details(search_term)
+                except Exception as e:
+                    digikey_part = None
+                    continue
+        # Removed matching on digikey part number as the new api matches on manufacturer product number
+        # Thus, removing the need to use keyword_search to find manufacturers product number
+        # The logic for keyword search is still useful for partial matches.
+        # The line below is the original line updated for the v4 api.
+        # if digikey_part and search_term == digikey_part.product.product_variations[0].digi_key_product_number:
+        if digikey_part:
+            return [self.get_api_part(digikey_part.product)], 1
+        
 
         for retry in retry_timeouts():
             with retry:
-                results = digikey.keyword_search(
-                    body=KeywordSearchRequest(keywords=search_term, record_count=10),
-                    x_digikey_locale_currency=self.currency,
-                    x_digikey_locale_site=self.location,
-                    x_digikey_locale_language=self.language,
+                results = self.client.keyword_search(
+                    body=KeywordRequest(keywords=search_term, limit=10),
                 )
 
-        if results.exact_manufacturer_products_count > 0:
-            filtered_results = results.exact_manufacturer_products
-            product_count = results.exact_manufacturer_products_count
+        if len(results.exact_matches) > 0:
+            filtered_results = results.exact_matches
+            product_count = len(results.exact_matches)
         else:
             filtered_results = [
                 digikey_part for digikey_part in results.products
-                if digikey_part.manufacturer_part_number.lower().startswith(search_term.lower())
+                if digikey_part.manufacturer_product_number.lower().startswith(search_term.lower())
             ]
             product_count = results.products_count
 
         exact_matches = [
             digikey_part for digikey_part in filtered_results
-            if digikey_part.manufacturer_part_number.lower() == search_term.lower()
+            if digikey_part.manufacturer_product_number.lower() == search_term.lower()
         ]
         if len(exact_matches) == 1:
             return [self.get_api_part(exact_matches[0])], 1
@@ -85,33 +91,53 @@ class DigiKey(Supplier):
         product_count = max(product_count, len(filtered_results))
         return list(map(self.get_api_part, filtered_results)), product_count
 
-    def get_api_part(self, digikey_part: KeywordSearchResponse):
+    def get_api_part(self, digikey_part: Product):
         quantity_available = (
             digikey_part.quantity_available + digikey_part.manufacturer_public_quantity)
 
-        category_path = [digikey_part.category.value, *digikey_part.family.value.split(" - ")]
+        # Categories are stored in a tree structure, so we need to build the full path
+        category_path = [digikey_part.category.name]
+        num_child = len(digikey_part.category.child_categories)
+        child_categories = digikey_part.category.child_categories
 
+        while num_child > 0:
+            child_category = child_categories[0]
+            category_path.append(child_category.name)
+            num_child = len(child_category.child_categories)
+            child_categories = child_category.child_categories
+        
         parameters = {
-            parameter.parameter: parameter.value
+            parameter.parameter_text: parameter.value_text
             for parameter in digikey_part.parameters
         }
+        # Only single unit pricing is available from the ProductDetails API
+        # If we want to add price breaks need to make a seperate call to ProductPricing API 
+        # https://developer.digikey.com/products/product-information-v4/productsearch/productpricing
+        price_breaks = {1: digikey_part.unit_price}
 
-        price_breaks = {
-            price_break.break_quantity: price_break.unit_price
-            for price_break in digikey_part.standard_pricing
-        }
+
+        # Had issue with some products missing http/https in the datasheet url
+        datasheet_url = digikey_part.datasheet_url
+        if datasheet_url.startswith("//"):
+            datasheet_url = "https:" + datasheet_url
+        if not datasheet_url.startswith("http"):
+            datasheet_url = ""
+        
+        # Digikey part number now stored in product_variations
+        digikey_part_number = digikey_part.product_variations[0].digi_key_product_number
 
         return ApiPart(
-            description=digikey_part.product_description,
-            image_url=digikey_part.primary_photo,
-            datasheet_url=digikey_part.primary_datasheet,
+            description=digikey_part.description.product_description,
+            image_url=digikey_part.photo_url,
+            datasheet_url=datasheet_url,
             supplier_link=digikey_part.product_url,
-            SKU=digikey_part.digi_key_part_number,
-            manufacturer=digikey_part.manufacturer.value,
+            SKU=digikey_part_number,
+            manufacturer=digikey_part.manufacturer.name,
             manufacturer_link="",
-            MPN=digikey_part.manufacturer_part_number,
+            MPN=digikey_part.manufacturer_product_number,
             quantity_available=quantity_available,
-            packaging=digikey_part.packaging.value,
+            # packing information not in ProductDetails API
+            packaging="",#digikey_part.packaging.value,
             category_path=category_path,
             parameters=parameters,
             price_breaks=price_breaks,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inventree-part-import"
-version = "1.8.1"
+version = "1.9"
 description = "CLI to import parts from suppliers like DigiKey, LCSC, Mouser, etc. to InvenTree"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -18,7 +18,7 @@ dependencies = [
     "browser-cookie3",
     "click",
     "cutie",
-    "digikey-api>=1.0",
+    "digikey-api @ git+https://github.com/flaviut/digikey-api.git",
     "fake-useragent",
     "inventree>=0.13.2",
     "isocodes",
@@ -71,3 +71,6 @@ pythonpath = ["."]
 
 [tool.codespell]
 ignore-words-list = "leaded"
+
+[tool.hatch.metadata]
+allow-direct-references = true


### PR DESCRIPTION
Changed digikey-api dependency to reference https://github.com/flaviut/digikey-api until the main repo is updated to fix the v4 issues. Made the suppliers_digikey.py file compatible with the new repo and api.

Product details and search working however, only single unit price is updated, and packaging is left blank as there is no simple way to access this information. 