### PR TITLE
suppliers: fix TME unknown PriceType key

### DIFF
--- a/inventree_part_import/suppliers/supplier_tme.py
+++ b/inventree_part_import/suppliers/supplier_tme.py
@@ -73,9 +73,8 @@ class TME(Supplier):
         return list(map(self.get_api_part, filtered_matches, tme_stocks)), len(filtered_matches)
 
     def get_api_part(self, tme_part, tme_stock):
-        to_net_price = 1 if tme_stock["PriceType"] == "NET" else 100 / (100 + tme_stock["VatRate"])
         price_breaks = {
-            price_break["Amount"]: price_break["PriceValue"] * to_net_price
+            price_break["Amount"]: price_break["PriceValue"]
             for price_break in tme_stock.get("PriceList", [])
         }
 


### PR DESCRIPTION
Fixes #66

I am not sure why, but PriceType key went missing.

This was used to remove VAT if the price type was `!= "NET"`. Turns the check is not needed to begin with because `VatRate` is set to 0 if the price type would be NET.

That means the ratio calculation:
```py
to_net_price = 100 / (100 + tme_stock["VatRate"])
```
give us:
```py
to_net_price = 100 / (100 + 0)
```
which is `100 / 100` which is `1` so no-op for NET prices.