### PR TITLE
fix: make get_supplier_part only return matches if the company match

### DIFF
--- a/inventree_part_import/inventree_helpers.py
+++ b/inventree_part_import/inventree_helpers.py
@@ -22,9 +22,6 @@ INVENTREE_CACHE.mkdir(parents=True, exist_ok=True)
 
 def get_supplier_part(inventree_api: InvenTreeAPI, company: InventreeCompany, sku):
     supplier_parts = SupplierPart.list(inventree_api, SKU=sku)
-    if len(supplier_parts) == 1:
-        return supplier_parts[0]
-
     company_supplier_parts = [part for part in supplier_parts if part.supplier == company.pk]
     if len(company_supplier_parts) == 1:
         return company_supplier_parts[0]


### PR DESCRIPTION
I had a bug starting due two suppliers (TME & TI) both use the same SKU, then it creates the TI supplier part everything is fine, after that it creates the TME supplier part, does a SKU search only find one single result and return it as the existing supplier part even tho this is TI's supplier part not TME's.
Then TME would proceed to update the TI supplier part with the TME info.

Making a last one wins and making it impossible for boths to be listed for the same part.