### PR TITLE
pyproject.toml: specify python 3.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "inventree-part-import"
 version = "1.8.1"
 description = "CLI to import parts from suppliers like DigiKey, LCSC, Mouser, etc. to InvenTree"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<4.0"
 classifiers = [
     "Environment :: Console",
     "Operating System :: OS Independent",


### PR DESCRIPTION
This fixes `peotry install`:

The current project's supported Python range (>=3.10) is not compatible with some of the required packages Python requirement:
  - mouser requires Python <4.0,>=3.8, so it will not be installable for Python >=4.0